### PR TITLE
0.1.0 release preparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,6 @@ virtualenv:
 
 sudo: false
 
+install: pip install --upgrade setuptools
+
 script: ./setup.py install

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 Dependencies for testing OME Ansible roles with Molecule
 ========================================================
 
+.. image:: https://travis-ci.org/openmicroscopy/ome-ansible-molecule-dependencies.png
+   :target: http://travis-ci.org/openmicroscopy/ome-ansible-molecule-dependencies
+
+.. image:: https://badge.fury.io/py/ome-ansible-molecule-dependencies.svg
+    :target: https://badge.fury.io/py/ome-ansible-molecule-dependencies
+
 A meta-package that installs common dependencies required to test most `OME Ansible Galaxy roles <https://galaxy.ansible.com/openmicroscopy/>`_.
 
 Example `.travis.yml` file for testing Ansible roles:

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='ome-ansible-molecule-dependencies',
-    version='0.0.1',
+    version='0.1.0',
 
     description='Dependencies for testing OME Ansible roles',
     long_description=long_description,
 
-    url='https://github.com/ome/ome-ansible-molecule-dependencies',
+    url='https://github.com/openmicroscopy/ome-ansible-molecule-dependencies',
 
     author='The Open Microscopy Team',
     author_email='ome-devel@lists.openmicroscopy.org.uk',


### PR DESCRIPTION
Preparation for 0.1.0 release (from the organization) including:

- version number bump
- hyperlinks to Pypi and Travis in README
- update URL to the parent repository