### PR TITLE
Bump ansible dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     # Bug in Ansible 2.2.2: https://github.com/ansible/ansible/issues/23016
     install_requires=[
-        'ansible==2.2.1.0',
+        'ansible==2.3.1',
         'docker',
-        'molecule==1.23',
+        'molecule==1.25',
     ],
 )


### PR DESCRIPTION
Attempts a migration to ansible 2.3 across the currently passing roles.