### PR TITLE
Ansible 2.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ script:
 # molecule test playbooks expect the directory to match the repository name
 - mv openmicroscopy.$ROLE ansible-role-$ROLE
 - cd ansible-role-$ROLE
+# Some roles can't be properly tested in Docker
+# These should provide an alternative configuration just for testing syntax
+- if [ -f molecule-docker.yml ]; then mv molecule-docker.yml molecule.yml; fi
 - ../test.sh
 
 ### GENERATED ###
@@ -29,6 +32,7 @@ env:
 - ROLE=docker
 - ROLE=docker-tools
 - ROLE=haproxy
+# Syntax only
 - ROLE=hosts-populate
 - ROLE=ice
 - ROLE=java
@@ -41,6 +45,7 @@ env:
 - ROLE=mysql-backup
 - ROLE=network-cloud-interfaces
 - ROLE=nfs-mount
+# Syntax only
 - ROLE=nfs-share
 - ROLE=nginx
 - ROLE=nginx-proxy
@@ -68,16 +73,14 @@ env:
 - ROLE=versioncontrol-utils
 ### GENERATED ###
 
+### molecule syntax check only
+
 matrix:
   allow_failures:
   # Uses a non-standard test from upstream
   - env: ROLE=haproxy
-  # Molecule test requires vagrant
-  - env: ROLE=hosts-populate
   # No molecule.yml or test.yml (tested by munin role)
   - env: ROLE=munin-node
-  # Molecule test requires vagrant
-  - env: ROLE=nfs-share
   # Molecule test doesn't work
   - env: ROLE=omero-logmonitor
   # Broken (deprecated?)

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
 - ROLE=celery-docker
 - ROLE=docker
 - ROLE=docker-tools
+- ROLE=haproxy
 - ROLE=hosts-populate
 - ROLE=ice
 - ROLE=java
@@ -36,9 +37,11 @@ env:
 - ROLE=logrotate
 - ROLE=lvm-partition
 - ROLE=munin
+- ROLE=munin-node
 - ROLE=mysql-backup
 - ROLE=network-cloud-interfaces
 - ROLE=nfs-mount
+- ROLE=nfs-share
 - ROLE=nginx
 - ROLE=nginx-proxy
 - ROLE=nginx-ssl-selfsigned
@@ -48,6 +51,7 @@ env:
 - ROLE=omero-server
 - ROLE=omero-user
 - ROLE=omero-web
+- ROLE=omero-web-apps
 - ROLE=omero-web-runtime
 - ROLE=openstack-volume-storage
 - ROLE=postgresql
@@ -63,3 +67,18 @@ env:
 - ROLE=upgrade-distpackages
 - ROLE=versioncontrol-utils
 ### GENERATED ###
+
+matrix:
+  allow_failures:
+  # Uses a non-standard test from upstream
+  - env: ROLE=haproxy
+  # Molecule test requires vagrant
+  - env: ROLE=hosts-populate
+  # No molecule.yml or test.yml (tested by munin role)
+  - env: ROLE=munin-node
+  # Molecule test requires vagrant
+  - env: ROLE=nfs-share
+  # Molecule test doesn't work
+  - env: ROLE=omero-logmonitor
+  # Broken (deprecated?)
+  - env: ROLE=omero-web-apps

--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,8 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    # Bug in Ansible 2.2.2: https://github.com/ansible/ansible/issues/23016
     install_requires=[
-        'ansible==2.3.1',
+        'ansible==2.3.2',
         'docker',
         'molecule==1.25',
     ],

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,6 @@ setup(
     install_requires=[
         'ansible==2.3.2',
         'docker',
-        'molecule==1.25',
+        'molecule==1.25.1',
     ],
 )


### PR DESCRIPTION
Bumps Ansible to 2.3.2.
Adds all openmicroscopy galaxy roles to travis, and marks some as failing.