### PR TITLE
Force installation of molecule before ansible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,8 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
+        'molecule==1.25.1',
         'ansible==2.3.2',
         'docker',
-        'molecule==1.25.1',
     ],
 )


### PR DESCRIPTION
With the recent release of PyYAML 4.1, our Ansible roles started to fail Travis testing - see https://travis-ci.org/openmicroscopy/ansible-role-haproxy/builds/397223651 for an example of issue

Looking into the details:
- this role declares a dependency on `molecule==1.25.1` which itself depends on `PyYAML==3.12` and `ansible==2.3.2` which depends on uncapped `PyYAML`
- the rules for the transitive dependency resolution are unclear to me. Locally (OSX 10.13.5) `venv/bin/pip install ome-ansible-molecule-dependencies` installs PyYAML 3.1.2 but on Travis (Ubuntu 14.04) installs PyYAML 4.1.

Inverting the order of `molecule` and `ansible` in the `install_requires` step seems to be sufficient to install the 3.12 version of PyYAML - see https://travis-ci.org/sbesson/ansible-role-haproxy/builds/397286128 for an run of the role using this branch.

Rather than hardcoding `pip install PyYAML==3.12` across all Ansible roles, this path seems to be the one with the less amount of changes i.e. cut a `3.0.1` PyPI release that can be consumed by all Ansible roles without change and will install the correct version of `PyYAML`.

Additional notes:
- if we cut a release, I could as well publish `3.0.0` which was never pushed to PyPI although the tag exists
- if no-one does it, we should probably report the issues between PyYAML 4.1 and Ansible(-lint) 2.3. Debugging is extremely tricky as `ansible-lint` uses overloaded `yaml` classes in `ansible.parsing.yaml` so there are are least 3 libraries here and we are using already a fairly old version of Ansible
