### PR TITLE
Bump to Ansible 2.6 and Molecule 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 Dependencies for testing OME Ansible roles with Molecule
 ========================================================
 
-.. image:: https://travis-ci.org/openmicroscopy/ome-ansible-molecule-dependencies.png
-   :target: http://travis-ci.org/openmicroscopy/ome-ansible-molecule-dependencies
+.. image:: https://travis-ci.org/openmicroscopy/ome-ansible-molecule.png
+   :target: http://travis-ci.org/openmicroscopy/ome-ansible-molecule
 
-.. image:: https://badge.fury.io/py/ome-ansible-molecule-dependencies.svg
-    :target: https://badge.fury.io/py/ome-ansible-molecule-dependencies
+.. image:: https://badge.fury.io/py/ome-ansible-molecule.svg
+    :target: https://badge.fury.io/py/ome-ansible-molecule
 
 A meta-package that installs common dependencies required to test most `OME Ansible Galaxy roles <https://galaxy.ansible.com/openmicroscopy/>`_.
 
@@ -21,7 +21,7 @@ Example `.travis.yml` file for testing Ansible roles:
       - docker
 
     install:
-      - pip install ome-ansible-molecule-dependencies
+      - pip install ome-ansible-molecule
 
     script:
       - molecule test

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,8 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'molecule==1.25.1',
-        'ansible==2.3.2',
-        'docker',
+        'ansible==2.6.3',
+        'docker-compose',
+        'molecule>=2.4'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='ome-ansible-molecule',
-    version='0.3.2.dev1',
+    version='0.4.0.dev1',
 
     description='Dependencies for testing OME Ansible roles',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
         'ansible==2.6.3',
-        'docker-compose',
+        'docker-compose==1.22.0',
         'molecule>=2.4'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,13 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='ome-ansible-molecule-dependencies',
+    name='ome-ansible-molecule',
     version='0.3.2.dev1',
 
     description='Dependencies for testing OME Ansible roles',
     long_description=long_description,
 
-    url='https://github.com/openmicroscopy/ome-ansible-molecule-dependencies',
+    url='https://github.com/openmicroscopy/ome-ansible-molecule',
 
     author='The Open Microscopy Team',
     author_email='ome-devel@lists.openmicroscopy.org.uk',


### PR DESCRIPTION
As discussed earlier today, this new set of requirements supersedes the ones previously proposed in #10.