### PR TITLE
In readme cap recommendation to current major release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Dependencies for testing OME Ansible roles with Molecule
 
 A meta-package that installs common dependencies required to test most `OME Ansible Galaxy roles <https://galaxy.ansible.com/openmicroscopy/>`_.
 
-Example `.travis.yml` file for testing Ansible roles:
+Example ``.travis.yml`` file for testing Ansible roles:
 
 ..  code-block:: yaml
 

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Example `.travis.yml` file for testing Ansible roles:
       - docker
 
     install:
-      - pip install ome-ansible-molecule
+      - pip install "ome-ansible-molecule<0.5"
 
     script:
       - molecule test


### PR DESCRIPTION
This will allow us to make breaking changes without breaking existing Ansible role tests.