### PR TITLE
Bump Ansible version to 2.6.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'ansible==2.6.3',
+        'ansible==2.6.16',
         'docker-compose==1.22.0',
         'molecule==2.19'
     ],


### PR DESCRIPTION
Noticed while deploying `prod67`. The creation of the `router` failed with an issue similar to the one reported in https://github.com/ansible/ansible/issues/44432. Upgrading Ansible locally was sufficient to create the OpenStack infrastructure.

Increasing the Ansible version should include the latest bug and security fixes.

Proposed to release as `0.4.2`