### PR TITLE
Update links post organization transfer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Dependencies for testing OME Ansible roles with Molecule
 ========================================================
 
-.. image:: https://travis-ci.org/openmicroscopy/ome-ansible-molecule.png
-   :target: http://travis-ci.org/openmicroscopy/ome-ansible-molecule
+.. image:: https://travis-ci.org/ome/ome-ansible-molecule.png
+   :target: https://travis-ci.org/ome/ome-ansible-molecule
 
 .. image:: https://badge.fury.io/py/ome-ansible-molecule.svg
     :target: https://badge.fury.io/py/ome-ansible-molecule

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description='Dependencies for testing OME Ansible roles',
     long_description=long_description,
 
-    url='https://github.com/openmicroscopy/ome-ansible-molecule',
+    url='https://github.com/ome/ome-ansible-molecule',
 
     author='The Open Microscopy Team',
     author_email='ome-devel@lists.openmicroscopy.org.uk',


### PR DESCRIPTION
All OME PyPI repos should now be pulled from the GitHub OME organization