### PR TITLE
Ansible 2.8.18 molecule 2.22 python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,10 +66,10 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'ansible==2.9.5',
-        'docker-compose==1.25',
+        'ansible==2.9.11',
+        'docker-compose==1.26.2',
         'molecule==2.22',
-        'jmespath',
+        'jmespath==0.10.0',
     ],
     python_requires='>=3',
 )

--- a/setup.py
+++ b/setup.py
@@ -71,5 +71,5 @@ setup(
         'molecule==2.22',
         'jmespath==0.10.0',
     ],
-    python_requires='>=3',
+    python_requires='>=3.6',
 )

--- a/setup.py
+++ b/setup.py
@@ -66,9 +66,9 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'ansible==2.6.18',
-        'docker-compose==1.22.0',
-        'molecule==2.19',
+        'ansible==2.9.5',
+        'docker-compose==1.25',
+        'molecule==2.22',
         'jmespath',
     ],
     python_requires='>=3',

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'ansible==2.9.11',
+        'ansible==2.8.18',
         'docker-compose==1.26.2',
         'molecule==2.22',
         'jmespath==0.10.0',


### PR DESCRIPTION
Update to Ansible 2.~9~8 and Molecule 2.22 (the last version before the recently released 3.0).
These are the versions that happen to be in conda-forge right now.

In conjunction with https://github.com/ome/ome-ansible-molecule/pull/19 this could be released as `0.5.0`