### PR TITLE
Add jmespath to package dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ setup(
     install_requires=[
         'ansible==2.6.18',
         'docker-compose==1.22.0',
-        'molecule==2.19'
+        'molecule==2.19',
+        'jmespath',
     ],
     python_requires='>=3',
 )


### PR DESCRIPTION
This package is required for testing the ome.prometheus role

See https://github.com/ome/ansible-roles/pull/16#pullrequestreview-385568656

Proposing to release as `0.4.4` together with #19.