### PR TITLE
Add passlib dependency for OSX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         'docker-compose==1.26.2',
         'molecule==2.22',
         'jmespath==0.10.0',
+        'passlib==1.7.4; sys_platform=="darwin"',
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
This dependency is necessary in order to generate encrypted passwords for the user module - see https://docs.ansible.com/ansible/2.8/reference_appendices/faq.html?highlight=password%20crypted#how-do-i-generate-encrypted-passwords-for-the-user-module