### PR TITLE
Cap rich to version 10.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,8 @@ setup(
         'molecule==2.22',
         'jmespath==0.10.0',
         'passlib==1.7.4; sys_platform=="darwin"',
+        # https://github.com/ansible-community/ansible-lint/issues/1795
+        "rich<11.0.0",
     ],
     python_requires='>=3.6',
 )


### PR DESCRIPTION
The latest version of rich includes breaking changes that affects ansible-lint.

A new version of ansible-lint has just been released with support for rich 11 (see https://github.com/ansible-community/ansible-lint/releases/tag/v5.3.2) but our Ansible infrastructure is on Molecule 2 which caps ansible-lint to 4.x. Until we are ready to upgrade our infrastructure to Molecule 3, this should allow our Ansible CI to keep testing roles and playbooks