### PR TITLE
Bump Ansible to 2.10.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'ansible==2.9.27',
+        'ansible==2.10.7',
         'docker-compose==1.26.2',
         'molecule==2.22',
         'jmespath==0.10.0',


### PR DESCRIPTION
Currently investigated in the context of the IDR deployment although this might be propagated to all the OME Ansible infrastructure.

Immediately, having a version of this package with Ansible 2.10 would be useful to test https://github.com/IDR/ansible-role-openstack-idr-instance/pull/9.

Proposed tag: `0.7.0a1` or `0.7.0rc1`